### PR TITLE
Scan messages for URLs and add ClickEvent by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ Follow the [1.16](https://github.com/Mineaurion/aurionchat#forge-116) section fo
 
 The mod need [Luckperms](https://modrinth.com/mod/luckperms/versions) to be working with a minimal version of 5.1.20. The config file is the same syntax as the sponge one.
 
+## URL Mode
+Theres a variety of options available for handling URLs. Options are as follows:
+
+| Name                 | Value | Description                                                             |
+|----------------------|-------|-------------------------------------------------------------------------|
+| Allow URLs           | `1`   | When disabled, replaces scanned URLs with `[url removed]`               |
+| Allow HTTP           | `2`   | When enabled, does not enforce the use of `https://`                    |
+| Scan Domains         | `4`   | When enabled, scans for domains that have no leading `https://` as well |
+| Display Domains Only | `8`   | When enabled, displays only the domain portion of scanned URLs in chat  |
+
+The `options.url_mode` configuration value must be set to the sum of the values of all enabled options.
+
+For example;
+- to allow URLs and only display the domain portion; you'd have to set it to `9`.
+- to replace all URLs and domains with `[url removed]`, set it to `4`
+- to allow URLs and domains, and only display the domain portion; set it to `13`
+
 ## Automessage
 
 For this part to work you need to install this [plugin](https://github.com/Mineaurion/AurionChat-AutoMessage)  on one of our server. 

--- a/bukkit/src/main/java/com/mineaurion/aurionchat/bukkit/BukkitConfigurationAdapter.java
+++ b/bukkit/src/main/java/com/mineaurion/aurionchat/bukkit/BukkitConfigurationAdapter.java
@@ -48,7 +48,8 @@ public class BukkitConfigurationAdapter implements ConfigurationAdapter {
                     channel,
                     new Channel(
                             this.configuration.getString("channels." + channel + ".format"),
-                            this.configuration.getString("channels." + channel + ".alias")
+                            this.configuration.getString("channels." + channel + ".alias"),
+                            this.configuration.getInt("channels." + channel + ".url_mode", 1)
                     )
             );
         }

--- a/bukkit/src/main/java/com/mineaurion/aurionchat/bukkit/listeners/ChatListener.java
+++ b/bukkit/src/main/java/com/mineaurion/aurionchat/bukkit/listeners/ChatListener.java
@@ -37,7 +37,8 @@ public class ChatListener implements Listener {
         Component messageFormat = Utils.processMessage(
                 plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
                 LegacyComponentSerializer.legacy('&').deserialize(event.getMessage()).asComponent(),
-                aurionChatPlayer
+                aurionChatPlayer,
+                Utils.URL_MODE_ALLOW
         );
 
         try{

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -12,9 +12,12 @@ channels:
   global:
     format: "[GLOBAL] {prefix}{display_name} : &f{message}"
     alias: "g"
+    url_mode: 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
   infinity:
     format: "[&6I&f] {prefix}{display_name} : &f{message}"
     alias: "inf"
+    url_mode: 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
   revelation:
     format: "[&5R&f] {prefix}{display_name} : &f{message}"
     alias: "reve"
+    url_mode: 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     compileOnly 'com.google.code.gson:gson:2.7'
     compileOnly 'com.google.guava:guava:19.0'
+    compileOnly 'org.jetbrains:annotations:21.+'
 
     api('net.kyori:adventure-api:4.11.0') {
         exclude(module: 'adventure-bom')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 test {
-    useJUnitPlatform {}
+    useJUnit()
+    include '**/Test*.class'
 }
 
 jacocoTestReport {
@@ -53,4 +54,7 @@ dependencies {
     api('org.spongepowered:configurate-yaml:4.1.2')
     api('org.spongepowered:configurate-gson:4.1.2')
     api('org.spongepowered:configurate-hocon:4.1.2')
+
+    testImplementation('junit:junit:4.12')
+    testImplementation('org.easymock:easymock:3.6')
 }

--- a/common/src/main/java/com/mineaurion/aurionchat/common/Utils.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/Utils.java
@@ -21,6 +21,8 @@ public class Utils {
             "(?<protocol>https?://)? # http/s \n" +
             "(?<domain>([\\w-]+\\.)*([\\w-]+(\\.[\\w-]+)+?)) # domains with * subdomains and +? endings \n" +
             "(?<path>(/[\\w-_.]+)*/?) # url path \n" +
+            "(\\#(?<fragment>[\\w_-]+))? # url fragment \n" +
+            "(?<parameters>\\?(([\\w_%-]+)=([\\w_%-]+)&?))? # urlencoded parameters \n" +
             ").*? # append anything");
     public static final int URL_MODE_ALLOW = 0x1;
     public static final int URL_MODE_ALLOW_HTTP = 0x2;

--- a/common/src/main/java/com/mineaurion/aurionchat/common/Utils.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/Utils.java
@@ -2,24 +2,37 @@ package com.mineaurion.aurionchat.common;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.intellij.lang.annotations.MagicConstant;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static net.kyori.adventure.text.format.NamedTextColor.WHITE;
-
 public class Utils {
-    public static Component processMessage(String format, Component message, AurionChatPlayer aurionChatPlayer){
-        if(!aurionChatPlayer.isAllowedColors()){
+    private static final Pattern URL_PATTERN = Pattern.compile("(?xi) # comments and case insensitive \n" +
+            "(.*?)( # prepend least possible of anything and group actual result \n" +
+            "(?<protocol>https?://)? # http/s \n" +
+            "(?<domain>([\\w-]+\\.)*([\\w-]+(\\.[\\w-]+)+?)) # domains with * subdomains and +? endings \n" +
+            "(?<path>(/[\\w-_.]+)*/?) # url path \n" +
+            ").*? # append anything");
+    public static final int URL_MODE_ALLOW = 0x1;
+    public static final int URL_MODE_ALLOW_HTTP = 0x2;
+    public static final int URL_MODE_SCAN_DOMAINS = 0x4;
+    public static final int URL_MODE_DISPLAY_ONLY_DOMAINS = 0x8;
+
+    public static Component processMessage(String format, Component message, AurionChatPlayer aurionChatPlayer,
+                                           @MagicConstant(flagsFromClass = Utils.class) int urlMode) {
+        if (!aurionChatPlayer.isAllowedColors()) {
             Component messageWithoutStyle = Component.text("");
-            if(!message.children().isEmpty()){
-                for (Component component: message.children()) {
+            if (!message.children().isEmpty()) {
+                for (Component component : message.children()) {
                     messageWithoutStyle = messageWithoutStyle.append(removeAllStyleAndColor(component));
                 }
             } else {
@@ -28,12 +41,48 @@ public class Utils {
             message = messageWithoutStyle;
         }
 
-        String[] formatSplit = format.split("\\{message\\}");
+        String[] formatSplit = format.split("\\{message}");
 
-        Component beforeMessage = replaceToken(formatSplit[0], aurionChatPlayer);
-        Component afterMessage = replaceToken(formatSplit.length == 2 ? formatSplit[1] : "", aurionChatPlayer);
+        Component blob = replaceToken(formatSplit[0], aurionChatPlayer);
+        final String display = getDisplayString(message);
+        final Matcher matcher = URL_PATTERN.matcher(display);
+        int eIndex = display.length();
+        while (matcher.find()) {
+            eIndex = matcher.end();
 
-        return beforeMessage.append(message).append(afterMessage);
+            // append text before url
+            blob = blob.append(Component.text(matcher.group(1)));
+
+            String urlDisplay = matcher.group(2), urlAction;
+
+            // check protocol present
+            if (matcher.group("protocol") == null) {
+                // validate that simple domains should be scanned
+                if ((urlMode & URL_MODE_SCAN_DOMAINS) == 0) {
+                    // otherwise append url as plaintext and continue
+                    blob = blob.append(Component.text(urlDisplay));
+                    continue;
+                }
+                urlAction = "https://" + urlDisplay;
+            }
+            // check enforce https
+            else if ((urlMode & URL_MODE_ALLOW_HTTP) == 0 && urlDisplay.startsWith("http:"))
+                urlAction = urlDisplay = urlDisplay.replace("http:", "https:");
+                // or just use the url
+            else urlAction = urlDisplay;
+
+            // check display mode
+            if ((urlMode & URL_MODE_DISPLAY_ONLY_DOMAINS) != 0)
+                urlDisplay = matcher.group("domain");
+
+            // check urls allowed
+            if ((urlMode & URL_MODE_ALLOW) != 0)
+                blob = blob.append(Component.text(urlDisplay)
+                        .clickEvent(ClickEvent.openUrl(urlAction)));
+            else blob = blob.append(Component.text("[url removed]"));
+        }
+        return blob.append(Component.text(display.substring(eIndex)))
+                .append(replaceToken(formatSplit.length == 2 ? formatSplit[1] : "", aurionChatPlayer));
     }
 
     public static String getDisplayString(Component component) {
@@ -54,7 +103,7 @@ public class Utils {
                 .collect(Collectors.joining());
     }
 
-    private static Component replaceToken(String text, AurionChatPlayer aurionChatPlayer){
+    private static Component replaceToken(String text, AurionChatPlayer aurionChatPlayer) {
         return LegacyComponentSerializer.legacy('&').deserialize(
                 text.replace("{prefix}", aurionChatPlayer.getPlayer().getPreffix())
                         .replace("{suffix}", aurionChatPlayer.getPlayer().getSuffix())
@@ -62,7 +111,7 @@ public class Utils {
         );
     }
 
-    private static Component removeAllStyleAndColor(Component component){
+    private static Component removeAllStyleAndColor(Component component) {
         return component
                 .style(Style.empty())
                 .decorations(

--- a/common/src/main/java/com/mineaurion/aurionchat/common/command/ChatCommandCommon.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/command/ChatCommandCommon.java
@@ -128,7 +128,7 @@ public class ChatCommandCommon {
 
     public boolean onCommand(AurionChatPlayer aurionChatPlayers, Component message, String channel, String format){
         aurionChatPlayers.addChannel(channel);
-        Component messageFormat = Utils.processMessage(format, message, aurionChatPlayers);
+        Component messageFormat = Utils.processMessage(format, message, aurionChatPlayers, Utils.URL_MODE_ALLOW);
         try {
             plugin.getChatService().send(channel, messageFormat);
             return true;

--- a/common/src/main/java/com/mineaurion/aurionchat/common/config/Channel.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/config/Channel.java
@@ -2,11 +2,13 @@ package com.mineaurion.aurionchat.common.config;
 
 public class Channel {
 
-    public Channel(String format, String alias){
+    public Channel(String format, String alias, int urlMode){
         this.format = format;
         this.alias = alias;
+        this.urlMode = urlMode;
     }
 
     public String format;
     public String alias;
+    public int urlMode;
 }

--- a/common/src/main/java/com/mineaurion/aurionchat/common/config/ConfigurateConfigAdapter.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/config/ConfigurateConfigAdapter.java
@@ -60,7 +60,10 @@ public abstract class ConfigurateConfigAdapter implements ConfigurationAdapter {
         return node.childrenMap().entrySet().stream().collect(
                 Collectors.toMap(
                         k -> k.getKey().toString(),
-                        v -> new Channel(v.getValue().node("format").getString(), v.getValue().node("alias").getString())
+                        v -> new Channel(
+                                v.getValue().node("format").getString(),
+                                v.getValue().node("alias").getString(),
+                                v.getValue().node("url_mode").getInt(1))
                 )
         );
     }

--- a/common/src/test/java/TestMessageProcessing.java
+++ b/common/src/test/java/TestMessageProcessing.java
@@ -1,0 +1,200 @@
+import com.mineaurion.aurionchat.common.AbstractAurionChat;
+import com.mineaurion.aurionchat.common.AurionChatPlayer;
+import com.mineaurion.aurionchat.common.config.ConfigurationAdapter;
+import com.mineaurion.aurionchat.common.player.Player;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import static com.mineaurion.aurionchat.common.Utils.*;
+import static net.kyori.adventure.text.Component.text;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+@SuppressWarnings("HttpUrlsUsage")
+public class TestMessageProcessing {
+    static String prefix = "[U]";
+    static String displayName = "Kaleidox";
+    static String suffix = "!";
+    static String formatPrefix = "Minecraft {prefix} {display_name}{suffix}: ";
+    static String testUrl1 = "java.com";
+    static String testUrl2 = "minecraft.net";
+    static String testUrlRemoved = "[url removed]";
+    static String testBase = "here is a url; %s and here is another: %s thats all there is!";
+
+    static String testUrlClickable(String it) {
+        return "https://" + it;
+    }
+
+    static String testUrlHttp(String it) {
+        return "http://" + it;
+    }
+
+    static String format() {
+        return formatPrefix
+                .replace("{display_name}", displayName)
+                .replace("{prefix}", prefix)
+                .replace("{suffix}", suffix);
+    }
+
+    static String testText(String url1, String url2, boolean output) {
+        String format = String.format(testBase, url1, url2);
+        return output
+                ? format()+format
+                : format;
+    }
+
+    Player playerAdp;
+    ConfigurationAdapter configAdp;
+    AbstractAurionChat plugin;
+    AurionChatPlayer player;
+
+    @Before
+    public void setupAurionChatPlayer() {
+        playerAdp = mock(Player.class);
+        configAdp = mock(ConfigurationAdapter.class);
+        plugin = mock(AbstractAurionChat.class);
+
+        // we could specify call count here for micro-optimization
+        expect(playerAdp.getDisplayName()).andReturn(displayName).atLeastOnce();
+        expect(playerAdp.getPreffix()).andReturn(prefix).atLeastOnce();
+        expect(playerAdp.getSuffix()).andReturn(suffix).atLeastOnce();
+        expect(playerAdp.hasPermission("aurionchat.chat.colors")).andReturn(true).atLeastOnce();
+        expect(configAdp.getChannels()).andReturn(new HashMap<>()).anyTimes();
+        expect(plugin.getConfigurationAdapter()).andReturn(configAdp).anyTimes();
+
+        replay(playerAdp, configAdp, plugin);
+        player = new AurionChatPlayer(playerAdp, plugin);
+    }
+
+    @After
+    public void teardown() {
+        verify(playerAdp, configAdp, plugin);
+        reset(playerAdp, configAdp, plugin);
+    }
+
+    void checkClickable(Component output, int ci, int ui, UnaryOperator<String> urlFunc) {
+        String url = new String[]{testUrl1,testUrl2}[ui];
+        List<Component> children = output.children();
+        assertTrue("invalid children count", children.size() > ci);
+        ClickEvent event = children.get(ci).clickEvent();
+        assertNotNull("url is not clickable: " + url, event);
+        assertEquals("event has wrong action", ClickEvent.Action.OPEN_URL, event.action());
+        assertEquals("event has wrong url", urlFunc.apply(url), event.value());
+    }
+
+    void checkNotClickable(Component output, int ci) {
+        List<Component> children = output.children();
+        assertTrue("invalid children count", children.size() > ci);
+        Component child = children.get(ci);
+        ClickEvent event = child.clickEvent();
+        assertNull("url should not be clickable: "+getDisplayString(child),event);
+    }
+
+    @Test
+    public void testDomain() {
+        Component output = processMessage(formatPrefix, text(testUrl1), player, URL_MODE_ALLOW);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", format()+testUrl1, displayString);
+
+        checkNotClickable(output, 0);
+    }
+
+    @Test
+    public void testDomainScan() {
+        Component output = processMessage(formatPrefix, text(testUrl1), player, URL_MODE_ALLOW | URL_MODE_SCAN_DOMAINS);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", format()+testUrl1, displayString);
+
+        checkClickable(output, 0, 0, TestMessageProcessing::testUrlClickable);
+    }
+
+    @Test
+    public void testUrl() {
+        Component output = processMessage(formatPrefix, text(testUrlClickable(testUrl1)), player, URL_MODE_ALLOW);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", format()+testUrlClickable(testUrl1), displayString);
+
+        checkClickable(output, 0, 0, TestMessageProcessing::testUrlClickable);
+    }
+
+    @Test
+    public void testEmbeddedUrl() {
+        Component output = processMessage(formatPrefix, text(testText(testUrl1, testUrlHttp(testUrl2), false)), player, URL_MODE_ALLOW);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", testText(testUrl1, testUrlClickable(testUrl2), true), displayString);
+
+        checkNotClickable(output, 1);
+        checkClickable(output, 3, 1, TestMessageProcessing::testUrlClickable);
+    }
+
+    @Test
+    public void testDeniedUrl() {
+        Component output = processMessage(formatPrefix, text(testText(testUrl1, testUrlClickable(testUrl2), false)), player, 0);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", testText(testUrl1, testUrlRemoved, true), displayString);
+
+        checkNotClickable(output, 1);
+        checkNotClickable(output, 3);
+    }
+
+    @Test
+    public void testDeniedUrlDomainScan() {
+        Component output = processMessage(formatPrefix, text(testText(testUrl1, testUrlClickable(testUrl2), false)), player, URL_MODE_SCAN_DOMAINS);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", testText(testUrlRemoved, testUrlRemoved, true), displayString);
+
+        checkNotClickable(output, 1);
+        checkNotClickable(output, 3);
+    }
+
+    @Test
+    public void testSimplifiedDisplay() {
+        Component output = processMessage(formatPrefix, text(testText(testUrl1, testUrlClickable(testUrl2), false)), player, URL_MODE_ALLOW | URL_MODE_DISPLAY_ONLY_DOMAINS);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", testText(testUrl1, testUrl2, true), displayString);
+
+        checkNotClickable(output, 1);
+        checkClickable(output, 3, 1, TestMessageProcessing::testUrlClickable);
+    }
+
+    @Test
+    public void testHttp() {
+        Component output = processMessage(formatPrefix, text(testText(testUrl1, testUrlHttp(testUrl2), false)), player, URL_MODE_ALLOW | URL_MODE_ALLOW_HTTP);
+
+        // check display
+        String displayString = getDisplayString(output);
+        System.out.println(displayString);
+        assertEquals("display string mismatch", testText(testUrl1, testUrlHttp(testUrl2), true), displayString);
+
+        checkNotClickable(output, 1);
+        checkClickable(output, 3, 1, TestMessageProcessing::testUrlHttp);
+    }
+}

--- a/fabric/src/main/java/com/mineaurion/aurionchat/fabric/listeners/ChatListener.java
+++ b/fabric/src/main/java/com/mineaurion/aurionchat/fabric/listeners/ChatListener.java
@@ -29,7 +29,8 @@ public class ChatListener implements ServerMessageEvents.AllowChatMessage {
         Component messageFormat = Utils.processMessage(
                 plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
                 GsonComponentSerializer.gson().deserialize(Text.Serializer.toJson(message.getContent())),
-                aurionChatPlayer
+                aurionChatPlayer,
+                Utils.URL_MODE_ALLOW
         );
         try {
             plugin.getChatService().send(currentChannel, messageFormat);

--- a/fabric/src/main/java/com/mineaurion/aurionchat/fabric/listeners/ChatListener.java
+++ b/fabric/src/main/java/com/mineaurion/aurionchat/fabric/listeners/ChatListener.java
@@ -3,6 +3,7 @@ package com.mineaurion.aurionchat.fabric.listeners;
 import com.mineaurion.aurionchat.common.AurionChatPlayer;
 import com.mineaurion.aurionchat.common.ChatService;
 import com.mineaurion.aurionchat.common.Utils;
+import com.mineaurion.aurionchat.common.config.Channel;
 import com.mineaurion.aurionchat.fabric.AurionChat;
 import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
 import net.kyori.adventure.text.Component;
@@ -26,11 +27,12 @@ public class ChatListener implements ServerMessageEvents.AllowChatMessage {
     public boolean allowChatMessage(SignedMessage message, ServerPlayerEntity sender, Parameters params) {
         AurionChatPlayer aurionChatPlayer = this.plugin.getAurionChatPlayers().get(sender.getUuid());
         String currentChannel = aurionChatPlayer.getCurrentChannel();
+        Channel channel = plugin.getConfigurationAdapter().getChannels().get(currentChannel);
         Component messageFormat = Utils.processMessage(
-                plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
+                channel.format,
                 GsonComponentSerializer.gson().deserialize(Text.Serializer.toJson(message.getContent())),
                 aurionChatPlayer,
-                Utils.URL_MODE_ALLOW
+                channel.urlMode
         );
         try {
             plugin.getChatService().send(currentChannel, messageFormat);

--- a/fabric/src/main/resources/aurionchat.conf
+++ b/fabric/src/main/resources/aurionchat.conf
@@ -11,13 +11,16 @@ channels {
     global {
         format = "[GLOBAL] {prefix}{display_name} : &f{message}"
         alias = "g"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
     infinity {
         format = "[&6I&f] {prefix}{display_name} : &f{message}"
         alias = "inf"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
     revelation {
         format = "[&5R&f] {prefix}{display_name} : &f{message}"
         alias = "reve"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
 }

--- a/forge/src/main/java/com/mineaurion/aurionchat/forge/listeners/ChatListener.java
+++ b/forge/src/main/java/com/mineaurion/aurionchat/forge/listeners/ChatListener.java
@@ -28,7 +28,8 @@ public class ChatListener {
         Component messageFormat = Utils.processMessage(
                 plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
                 GsonComponentSerializer.gson().deserialize(net.minecraft.network.chat.Component.Serializer.toJson(event.getMessage())),
-                aurionChatPlayer
+                aurionChatPlayer,
+                Utils.URL_MODE_ALLOW
         );
         try {
             plugin.getChatService().send(currentChannel, messageFormat);

--- a/forge/src/main/java/com/mineaurion/aurionchat/forge/listeners/ChatListener.java
+++ b/forge/src/main/java/com/mineaurion/aurionchat/forge/listeners/ChatListener.java
@@ -3,6 +3,7 @@ package com.mineaurion.aurionchat.forge.listeners;
 import com.mineaurion.aurionchat.common.AurionChatPlayer;
 import com.mineaurion.aurionchat.common.ChatService;
 import com.mineaurion.aurionchat.common.Utils;
+import com.mineaurion.aurionchat.common.config.Channel;
 import com.mineaurion.aurionchat.forge.AurionChat;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
@@ -25,11 +26,12 @@ public class ChatListener {
 
         AurionChatPlayer aurionChatPlayer = this.plugin.getAurionChatPlayers().get(event.getPlayer().getUUID());
         String currentChannel = aurionChatPlayer.getCurrentChannel();
+        Channel channel = plugin.getConfigurationAdapter().getChannels().get(currentChannel);
         Component messageFormat = Utils.processMessage(
-                plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
+                channel.format,
                 GsonComponentSerializer.gson().deserialize(net.minecraft.network.chat.Component.Serializer.toJson(event.getMessage())),
                 aurionChatPlayer,
-                Utils.URL_MODE_ALLOW
+                channel.urlMode
         );
         try {
             plugin.getChatService().send(currentChannel, messageFormat);

--- a/forge/src/main/resources/aurionchat.conf
+++ b/forge/src/main/resources/aurionchat.conf
@@ -11,13 +11,16 @@ channels {
     global {
         format = "[GLOBAL] {prefix}{display_name} : &f{message}"
         alias = "g"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
     infinity {
         format = "[&6I&f] {prefix}{display_name} : &f{message}"
         alias = "inf"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
     revelation {
         format = "[&5R&f] {prefix}{display_name} : &f{message}"
         alias = "reve"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
 }

--- a/sponge/src/main/java/com/mineaurion/aurionchat/sponge/listeners/ChatListener.java
+++ b/sponge/src/main/java/com/mineaurion/aurionchat/sponge/listeners/ChatListener.java
@@ -35,7 +35,8 @@ public class ChatListener {
         Component messageFormat = Utils.processMessage(
                 plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
                 event.message(),
-                aurionChatPlayer
+                aurionChatPlayer,
+                Utils.URL_MODE_ALLOW
         );
 
         try{

--- a/sponge/src/main/java/com/mineaurion/aurionchat/sponge/listeners/ChatListener.java
+++ b/sponge/src/main/java/com/mineaurion/aurionchat/sponge/listeners/ChatListener.java
@@ -3,6 +3,7 @@ package com.mineaurion.aurionchat.sponge.listeners;
 import com.mineaurion.aurionchat.common.AurionChatPlayer;
 import com.mineaurion.aurionchat.common.ChatService;
 import com.mineaurion.aurionchat.common.Utils;
+import com.mineaurion.aurionchat.common.config.Channel;
 import com.mineaurion.aurionchat.sponge.AurionChat;
 import net.kyori.adventure.text.Component;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
@@ -32,11 +33,12 @@ public class ChatListener {
         AurionChatPlayer aurionChatPlayer = this.plugin.getAurionChatPlayers().get(player.uniqueId());
 
         String currentChannel = aurionChatPlayer.getCurrentChannel();
+        Channel channel = plugin.getConfigurationAdapter().getChannels().get(currentChannel);
         Component messageFormat = Utils.processMessage(
-                plugin.getConfigurationAdapter().getChannels().get(currentChannel).format,
+                channel.format,
                 event.message(),
                 aurionChatPlayer,
-                Utils.URL_MODE_ALLOW
+                channel.urlMode
         );
 
         try{

--- a/sponge/src/main/resources/aurionchat.conf
+++ b/sponge/src/main/resources/aurionchat.conf
@@ -11,13 +11,16 @@ channels {
     global {
         format = "[GLOBAL] {prefix}{display_name} : &f{message}"
         alias = "g"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
     infinity {
         format = "[&6I&f] {prefix}{display_name} : &f{message}"
         alias = "inf"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
     revelation {
         format = "[&5R&f] {prefix}{display_name} : &f{message}"
         alias = "reve"
+        url_mode = 1 # check https://github.com/Mineaurion/Aurionchat/#url-mode for reference
     }
 }


### PR DESCRIPTION
Closes #30 

Implements support for URL based ClickEvents inside Components.

Configuration needs adjustment; as this accepts the following flags:
- `URL_MODE_ALLOW = 0x1`: When disabled, replaces scanned URLs with `[url removed]`
- `URL_MODE_ALLOW_HTTP = 0x2`: When enabled, does not enforce `https://` for scanned URLs
- `URL_MODE_SCAN_DOMAINS = 0x4`: When enabled, also scans simple domain names (e.g. `minecraft.net`)
- `URL_MODE_DISPLAY_ONLY_DOMAINS = 0x8`: When enabled, only displays domains for scanned URLs

Currently, default option `0x1` was inserted to older method calls.
Added Unit tests for processing are passing.