### PR TITLE
make clickable urls underlined

### DIFF
--- a/common/src/main/java/com/mineaurion/aurionchat/common/Utils.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/Utils.java
@@ -103,7 +103,9 @@ public class Utils {
                             urlAction = protocol + urlDisplay + matcher.group("url");
                         }
 
-                        Component clickComponent = urlAction.isEmpty() ? Component.text(urlDisplay) : Component.text(urlDisplay).clickEvent(ClickEvent.openUrl(urlAction));
+                        Component clickComponent = urlAction.isEmpty() ? Component.text(urlDisplay) : Component.text(urlDisplay)
+                                .decorate(TextDecoration.UNDERLINED)
+                                .clickEvent(ClickEvent.openUrl(urlAction));
 
                         builder.append(clickComponent);
                     }


### PR DESCRIPTION
sorry, i really should have thought about this earlier.
right now, especially when only showing domains of urls, theres no way to tell that a url in chat is clickable. underlining as a common style choice is done

possibly this could be improved using config