### PR TITLE
Add contextual permissions to limit users access to certain channels

### DIFF
--- a/common/src/main/java/com/mineaurion/aurionchat/common/exception/InsufficientPermissionException.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/exception/InsufficientPermissionException.java
@@ -1,0 +1,7 @@
+package com.mineaurion.aurionchat.common.exception;
+
+public class InsufficientPermissionException extends Exception{
+    public InsufficientPermissionException(String errorMessage){
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
This PR adds per-command-and-channel permissions for most commands, so that through permission management plugins, Administrators can limit access for users to certain channels; such as staff channels.