### PR TITLE
Do not stop receiving channels when changing current channel

### DIFF
--- a/common/src/main/java/com/mineaurion/aurionchat/common/command/ChatCommandCommon.java
+++ b/common/src/main/java/com/mineaurion/aurionchat/common/command/ChatCommandCommon.java
@@ -35,7 +35,7 @@ public class ChatCommandCommon {
 
     private void join(AurionChatPlayer aurionChatPlayer, String channel) throws ChannelNotFoundException {
         this.checkChannelExist(channel);
-        aurionChatPlayer.removeChannel(aurionChatPlayer.getCurrentChannel());
+        //aurionChatPlayer.removeChannel(aurionChatPlayer.getCurrentChannel());
         aurionChatPlayer.setCurrentChannel(channel);
         aurionChatPlayer.sendMessage(text("You have joined the " + channel + " channel.").color(GOLD));
     }


### PR DESCRIPTION
Otherwise, users must use `/ch spy` every time they joined another channel